### PR TITLE
Fix iOS/tvOS/watchOS platform support

### DIFF
--- a/svgnative/src/SVGNativeCWrapper.cpp
+++ b/svgnative/src/SVGNativeCWrapper.cpp
@@ -18,7 +18,7 @@ governing permissions and limitations under the License.
 #endif
 #ifdef USE_CG
 #include "svgnative/ports/cg/CGSVGRenderer.h"
-#include <ApplicationServices/ApplicationServices.h>
+#include <CoreServices/CoreServices.h>
 #include <CoreGraphics/CoreGraphics.h>
 #endif
 #ifdef USE_SKIA


### PR DESCRIPTION
Hi. @tjindal

The ApplicationServices is not available on those platform.

By replacing with CoreServices, I can sucessfully build on all Apple platforms:

+ macOS 12 SDK
+ iOS 15 SDK
+ tvOS 15 SDK
+ watchOS SDK 8

![image](https://user-images.githubusercontent.com/6919743/181729958-e9fd4c96-8cae-4183-8062-6c1cec3e13fe.png)
